### PR TITLE
Fixes deprecation not calling this._super

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   name: 'ember-restless',
 
   init: function(name) {
+    this._super(...arguments);
     this.treePaths['vendor'] = 'dist';
   },
 


### PR DESCRIPTION
Fixes following error in Ember:
DEPRECATION: Overriding init without calling this._super is deprecated. Please call this._super(), addon: `ember-restless` at Function.Addon.
DEPRECATION: Addon: `ember-restless` is missing addon.project, this may be the result of an addon forgetting to invoke `super` in its init.